### PR TITLE
Update docker setup to enable new HLE

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,6 @@ name: "skiller-whale-docker"
 services:
   sync:
     image: "ghcr.io/skiller-whale/learnersync:0.2.1"
-    network_mode: "host"
     environment:
       SERVER_URL: "https://train.skillerwhale.com/"
       SW_RUNNING_IN_HOSTED_ENV:
@@ -14,5 +13,3 @@ services:
     volumes:
       - ./exercises:/app/exercises:ro
       - ./attendance_id:/app/sync/attendance_id:ro
-    tty: true
-    stdin_open: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,13 +2,17 @@ version: "3.7"
 name: "skiller-whale-docker"
 services:
   sync:
-    image: "ghcr.io/skiller-whale/learnersync"
+    image: "ghcr.io/skiller-whale/learnersync:0.2.1"
+    network_mode: "host"
     environment:
       SERVER_URL: "https://train.skillerwhale.com/"
+      SW_RUNNING_IN_HOSTED_ENV:
       WATCHER_BASE_PATH: "/app/exercises"
       ATTENDANCE_ID_FILE: "/app/sync/attendance_id"
-      WATCHED_EXTS: "yml yaml html js"
+      WATCHED_EXTS: "Dockerfile .yml .yaml .html .js"
       IGNORE_DIRS: ".git"
     volumes:
       - ./exercises:/app/exercises:ro
       - ./attendance_id:/app/sync/attendance_id:ro
+    tty: true
+    stdin_open: true


### PR DESCRIPTION
This will make it possible for coaches to see when learners are running sync
from the hosted envionment, and track Dockerfiles.